### PR TITLE
予約情報のリマインダー機能実装

### DIFF
--- a/src/app/Console/Kernel.php
+++ b/src/app/Console/Kernel.php
@@ -2,6 +2,8 @@
 
 namespace App\Console;
 
+use App\Jobs\SendReservationReminderJob;
+use App\Models\Reservation;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -15,7 +17,12 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')->hourly();
+        $schedule->call(function () {
+            $reservations = Reservation::getTodayReservations();
+            foreach ($reservations as $reservation) {
+                dispatch(new SendReservationReminderJob($reservation));
+            }
+        })->dailyAt('09:00');
     }
 
     /**

--- a/src/app/Http/Controllers/ReservationController.php
+++ b/src/app/Http/Controllers/ReservationController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Jobs\SendReservationReminderJob;
 use App\Models\Reservation;
 use Illuminate\Support\Facades\Auth;
 
@@ -15,4 +16,5 @@ class ReservationController extends Controller
 
         return redirect()->route('customer.show');
     }
+
 }

--- a/src/app/Jobs/SendReservationReminderJob.php
+++ b/src/app/Jobs/SendReservationReminderJob.php
@@ -2,12 +2,12 @@
 
 namespace App\Jobs;
 
+use App\Mail\ReservationReminderMail;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use App\Mail\ReservationReminderMail;
 use Illuminate\Support\Facades\Mail;
 
 class SendReservationReminderJob implements ShouldQueue

--- a/src/app/Jobs/SendReservationReminderJob.php
+++ b/src/app/Jobs/SendReservationReminderJob.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use App\Mail\ReservationReminderMail;
+use Illuminate\Support\Facades\Mail;
+
+class SendReservationReminderJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public $reservation;
+
+    public function __construct($reservation)
+    {
+        $this->reservation = $reservation->toArray();
+    }
+
+    public function handle()
+    {
+        Mail::to($this->reservation['user_email'])->send(new ReservationReminderMail($this->reservation));
+    }
+}

--- a/src/app/Mail/ReservationReminderMail.php
+++ b/src/app/Mail/ReservationReminderMail.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class ReservationReminderMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $reservation;
+
+    public function __construct($reservation)
+    {
+        $this->reservation = $reservation;
+    }
+
+    public function build()
+    {
+        return $this->subject('【リマインダー】本日のご予約について')
+            ->view('emails.reservation_reminder')
+            ->with([
+                'reservation' => $this->reservation,
+            ]);
+    }
+}

--- a/src/app/Models/Reservation.php
+++ b/src/app/Models/Reservation.php
@@ -67,4 +67,28 @@ class Reservation extends Model
             ->where('user_id', $user->id)
             ->delete();
     }
+
+    public static function getTodayReservations()
+    {
+        return self::select(
+            'reservations.id',
+            'users.id as user_id',
+            'users.name as user_name',
+            'users.email as user_email',
+            'shops.name as shop_name',
+            'shops.id as shop_id',
+            'shops.name as shop_name',
+            'reservations.date',
+            'reservations.time',
+            'reservations.people'
+        )
+            ->join('users', 'reservations.user_id', '=', 'users.id')
+            ->join('shops', 'reservations.shop_id', '=', 'shops.id')
+            ->whereDate('reservations.date', today())
+            ->get()
+            ->map(function ($reservation) {
+                $reservation->time = Carbon::parse($reservation->time)->format('H:i');
+                return $reservation;
+            });
+    }
 }

--- a/src/config/queue.php
+++ b/src/config/queue.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'default' => env('QUEUE_CONNECTION', 'sync'),
+    'default' => env('QUEUE_CONNECTION', 'database'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/database/migrations/2025_01_30_000013_create_jobs_table.php
+++ b/src/database/migrations/2025_01_30_000013_create_jobs_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateJobsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('jobs');
+    }
+}

--- a/src/resources/views/emails/reservation_reminder.blade.php
+++ b/src/resources/views/emails/reservation_reminder.blade.php
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>予約リマインダー</title>
+</head>
+<body>
+    <p>{{ $reservation['user_name'] }} 様</p>
+    <p>本日「{{ $reservation['shop_name'] }}」にてご予約があります。</p>
+    <p>予約内容</p>
+    <ul>
+        <li>店舗: {{ $reservation['shop_name'] }} </li>
+        <li>予約日: {{ $reservation['date'] }} </li>
+        <li>予約時間: {{ $reservation['time'] }}</li>
+        <li>人数: {{ $reservation['people'] }}人</li>
+    </ul>
+    <p>お忘れないようご注意ください。</p>
+</body>
+</html>


### PR DESCRIPTION
予約情報のリマインダー機能を実装しました。

**仕様**

- 予約日の当日午前9:00に予約したユーザーへリマインドのメールを自動で送る。

**前提条件の設定**

1. .envファイルで以下の設定を行ってください。
```
QUEUE_CONNECTION=database

MAIL_MAILER=smtp
MAIL_HOST=sandbox.smtp.mailtrap.io
MAIL_PORT=2525
MAIL_USERNAME=mailtrapのEmail TestingにあるUsername
MAIL_PASSWORD=mailtrapのEmail TestingにあるPassword
MAIL_ENCRYPTION=null
MAIL_FROM_ADDRESS=mock-project03@example.com
MAIL_FROM_NAME="${APP_NAME}"
```

2. ターミナルで以下を実行してcronの設定ファイルを編集してください。
```
crontab -e //編集
crontab -l //内容確認
```

artisanのディレクトリを確認し、以下の記述をcronの設定ファイルの一番下に加えてください。
`* * * * * docker exec mock-project03-php-1 php /var/www/artisan schedule:run >> /dev/null 2>&1`


3.  /src/app/Console/Kernel.phpで指定された時間にジョブが作動しメールが送信されるか確認するには以下が起動されていることを確認してください。

ターミナルでcronを起動する
```
sudo cron status //起動しているか確認
sudo service cron start/stop　//起動/停止
sudo service cron restart　//再起動
```

phpコンテナでワーカーを起動する
```
php artisan queue:work　//起動
php artisan queue:restart　//再起動
```

上記の二つを起動後にジョブが実行される際の結果例：
```
root@24830029cc89:/var/www# php artisan queue:work
[2025-03-05 12:33:02][107] Processing: App\Jobs\SendReservationReminderJob
[2025-03-05 12:33:04][107] Processed:  App\Jobs\SendReservationReminderJob
```